### PR TITLE
#5 onnx inference via fuggingface optimum implementation.

### DIFF
--- a/backend/batched_inference/onnx.py
+++ b/backend/batched_inference/onnx.py
@@ -1,0 +1,12 @@
+from transformers import AutoTokenizer, pipeline
+from optimum.onnxruntime import ORTModelForCausalLM
+
+from batched_inference import huggingface
+
+class LLM(huggingface.LLM):
+    def __init__(self, hf_model_name_for_tokenizer, onnx_model_path, **kwargs):
+        tokenizer = AutoTokenizer.from_pretrained(hf_model_name_for_tokenizer)
+        model = ORTModelForCausalLM.from_pretrained(onnx_model_path, provider="CUDAExecutionProvider")
+        self._pipe = pipeline("text-generation", model=model, tokenizer=tokenizer, device="cuda")
+        if self._pipe.tokenizer.pad_token_id is None:
+            self._pipe.tokenizer.pad_token_id = self._pipe.tokenizer.eos_token_id


### PR DESCRIPTION
Currently not working on quantized and 7b models, but was successfully tested on smaller models(bigscience/bloom-1b1, stas/tiny-random-llama-2)

closes #5 