### PR TITLE
remove unnecessary code

### DIFF
--- a/backend/batched_inference/deepspeed.py
+++ b/backend/batched_inference/deepspeed.py
@@ -6,12 +6,6 @@ class LLM(huggingface.LLM):
     def __init__(self, model_name, **kwargs):
         super().__init__(model_name, **kwargs)
 
-        # model surgery for TheBloke/Llama-2-7b-AWQ
-        for module in self._pipe.model.modules():
-            if type(module).__name__ == "WQLinear_GEMM":
-                # creating attribute weight for quantized layers
-                module.weight = module.qweight
-
         self._pipe.model = deepspeed.init_inference(
             self._pipe.model,
             dtype=torch.int8,


### PR DESCRIPTION
Thought it was a hack to run awq models using deepspeed, turns out there are problems only when `replace_with_kernel_inject=True`